### PR TITLE
DownloadCollection overhaul

### DIFF
--- a/DownloadAlbum.user.js
+++ b/DownloadAlbum.user.js
@@ -4,7 +4,7 @@
 // @match       https://bandcamp.com/download*
 // @description Downloads the item from the download page. Refreshes if there is an error.
 // @author      Ryan Bluth, Xerus2000
-// @version     1.1
+// @version     1.1.1
 // @grant       none
 // ==/UserScript==
 
@@ -17,8 +17,8 @@
     var closeAfterDownload = true;
     
     var selectedFormat = false;
-    setTimeout(() => {
-        var interval = setInterval(() => {
+    setTimeout(function () {
+        var interval = setInterval(function () {
             if (!selectedFormat) {
                 document.getElementsByClassName('item-format button')[0].click();
                 var spans = document.getElementsByTagName('span');

--- a/DownloadAlbum.user.js
+++ b/DownloadAlbum.user.js
@@ -19,7 +19,7 @@
     var selectedFormat = false
     setTimeout(() => {
         var interval = setInterval(() => {
-            if(!selectedFormat){
+            if (!selectedFormat) {
                 document.getElementsByClassName('item-format button')[0].click()
                 var spans = document.getElementsByTagName("span")
 
@@ -49,7 +49,7 @@
                 if (titleLabel.children[0].href !== undefined && titleLabel.children[0].href.length > 0) {
                     window.open(titleLabel.children[0].href)
                     clearTimeout(interval)
-                    if(closeAfterDownload) {
+                    if (closeAfterDownload) {
                         close()
                     }
                 }

--- a/DownloadAlbum.user.js
+++ b/DownloadAlbum.user.js
@@ -9,48 +9,48 @@
 // ==/UserScript==
 
 (function () {
-    'use strict'
+    'use strict';
     
     // Set preferred download format here
-    var format = "MP3 320"
+    var format = "MP3 320";
     // Whether the download tab should automatically be closed after the download has been started
-    var closeAfterDownload = true
+    var closeAfterDownload = true;
     
-    var selectedFormat = false
+    var selectedFormat = false;
     setTimeout(() => {
         var interval = setInterval(() => {
             if (!selectedFormat) {
-                document.getElementsByClassName('item-format button')[0].click()
-                var spans = document.getElementsByTagName("span")
+                document.getElementsByClassName('item-format button')[0].click();
+                var spans = document.getElementsByTagName("span");
 
                 for (var i = 0; i < spans.length; i++) {
                   if (spans[i].textContent == format) {
-                    spans[i].parentElement.click()
-                    selectedFormat = true
-                    break
+                    spans[i].parentElement.click();
+                    selectedFormat = true;
+                    break;
                   }
                 }
             } else {
-                var errorText = document.getElementsByClassName("error-text")[0]
+                var errorText = document.getElementsByClassName("error-text")[0];
                 if (errorText.offsetParent !== null) {
-                    location.reload()
+                    location.reload();
                 }
 
                 try {
-                    var maintenanceLink = document.getElementsByTagName("a")[0]
+                    var maintenanceLink = document.getElementsByTagName("a")[0];
                     if (maintenanceLink.href.indexOf("bandcampstatus") > 0) {
-                        location.reload()
+                        location.reload();
                     }
                 } catch (e) {
-                    console.log(e)
+                    console.log(e);
                 }
 
-                var titleLabel = document.getElementsByClassName('download-title')[0]
+                var titleLabel = document.getElementsByClassName('download-title')[0];
                 if (titleLabel.children[0].href !== undefined && titleLabel.children[0].href.length > 0) {
-                    window.open(titleLabel.children[0].href)
-                    clearTimeout(interval)
+                    window.open(titleLabel.children[0].href);
+                    clearTimeout(interval);
                     if (closeAfterDownload) {
-                        close()
+                        close();
                     }
                 }
             }

--- a/DownloadAlbum.user.js
+++ b/DownloadAlbum.user.js
@@ -21,7 +21,7 @@
         var interval = setInterval(() => {
             if (!selectedFormat) {
                 document.getElementsByClassName('item-format button')[0].click();
-                var spans = document.getElementsByTagName("span");
+                var spans = document.getElementsByTagName('span');
 
                 for (var i = 0; i < spans.length; i++) {
                   if (spans[i].textContent == format) {
@@ -31,13 +31,13 @@
                   }
                 }
             } else {
-                var errorText = document.getElementsByClassName("error-text")[0];
+                var errorText = document.getElementsByClassName('error-text')[0];
                 if (errorText.offsetParent !== null) {
                     location.reload();
                 }
 
                 try {
-                    var maintenanceLink = document.getElementsByTagName("a")[0];
+                    var maintenanceLink = document.getElementsByTagName('a')[0];
                     if (maintenanceLink.href.indexOf("bandcampstatus") > 0) {
                         location.reload();
                     }

--- a/DownloadCollection.user.js
+++ b/DownloadCollection.user.js
@@ -22,48 +22,48 @@ var ignoreDuplicateTitles = true;
         mainContainer.style.display = 'none';
         return false;
     }
-    mainContainer.style.backgroundColor = "#1DA0C3";
-    mainContainer.style.position = "fixed";
-    mainContainer.style.color = "white";
-    mainContainer.style.top = "0";
-    mainContainer.style.left = "0";
-    mainContainer.style.right = "0";
-    mainContainer.style.padding = "20px";
-    mainContainer.style.zIndex = "9999999";
-    mainContainer.style.maxHeight = "75vh";
-    mainContainer.style.boxSizing = "border-box";
-    mainContainer.style.overflowY = "auto";
+    mainContainer.style.backgroundColor = '#1DA0C3';
+    mainContainer.style.position = 'fixed';
+    mainContainer.style.color = 'white';
+    mainContainer.style.top = '0';
+    mainContainer.style.left = '0';
+    mainContainer.style.right = '0';
+    mainContainer.style.padding = '20px';
+    mainContainer.style.zIndex = '9999999';
+    mainContainer.style.maxHeight = '75vh';
+    mainContainer.style.boxSizing = 'border-box';
+    mainContainer.style.overflowY = 'auto';
     mainContainer.innerHTML = '<div><h2><a style="color: inherit" href="https://github.com/RyanBluth/Bandcamp-Greasy">BANDCAMP GREASY</a></h2></div>';
     document.body.appendChild(mainContainer);
 
     var statusSpan = document.createElement('span');
-    statusSpan.style.fontWeight = "bold";
+    statusSpan.style.fontWeight = 'bold';
     statusSpan.innerText = "Loading albums...";
 
-    var downloadControls = document.createElement("div");
-    downloadControls.style.position = "fixed";
-    downloadControls.style.padding = "20px";
-    downloadControls.style.color = "black";
-    downloadControls.style.top = "0";
-    downloadControls.style.right = "0";
-    downloadControls.style.display = "none";
+    var downloadControls = document.createElement('div');
+    downloadControls.style.position = 'fixed';
+    downloadControls.style.padding = '20px';
+    downloadControls.style.color = 'black';
+    downloadControls.style.top = '0';
+    downloadControls.style.right = '0';
+    downloadControls.style.display = 'none';
 
-    var downloadAllButton = document.createElement("button");
+    var downloadAllButton = document.createElement('button');
     downloadAllButton.innerText = "Download All";
-    downloadAllButton.style.display = "block";
-    downloadAllButton.style.marginBottom = "10px";
+    downloadAllButton.style.display = 'block';
+    downloadAllButton.style.marginBottom = '10px';
     downloadAllButton.onclick = function () {
         for (var i = 0; i < allLinks.length; i++) {
             window.open(allLinks[i], '_blank');
         }
     }
 
-    var downloadSelectedButton = document.createElement("button");
+    var downloadSelectedButton = document.createElement('button');
     downloadSelectedButton.innerText = "Download Selected";
-    downloadSelectedButton.style.display = "block";
-    downloadSelectedButton.style.marginBottom = "10px";
+    downloadSelectedButton.style.display = 'block';
+    downloadSelectedButton.style.marginBottom = '10px';
     downloadSelectedButton.onclick = function () {
-        var checkboxes = mainContainer.getElementsByTagName("input");
+        var checkboxes = mainContainer.getElementsByTagName('input');
         for (var i = 0; i < checkboxes.length; i++) {
             if (checkboxes[i].checked) {
                 window.open(checkboxes[i].link, '_blank');
@@ -71,22 +71,22 @@ var ignoreDuplicateTitles = true;
         }
     }
 
-    var downloadRangeStart = document.createElement("input");
-    downloadRangeStart.type = "text";
-    downloadRangeStart.style.display = "block";
-    downloadRangeStart.style.marginBottom = "10px";
+    var downloadRangeStart = document.createElement('input');
+    downloadRangeStart.type = 'text';
+    downloadRangeStart.style.display = 'block';
+    downloadRangeStart.style.marginBottom = '10px';
     downloadRangeStart.placeholder = "Range Start";
 
-    var downloadRangeEnd = document.createElement("input");
-    downloadRangeEnd.type = "text";
-    downloadRangeEnd.style.display = "block";
-    downloadRangeEnd.style.marginBottom = "10px";
+    var downloadRangeEnd = document.createElement('input');
+    downloadRangeEnd.type = 'text';
+    downloadRangeEnd.style.display = 'block';
+    downloadRangeEnd.style.marginBottom = '10px';
     downloadRangeEnd.placeholder = "Range End";
 
-    var downloadRangeButton = document.createElement("button");
+    var downloadRangeButton = document.createElement('button');
     downloadRangeButton.innerText = "Download Range";
-    downloadRangeButton.style.display = "block";
-    downloadRangeButton.style.marginBottom = "10px";
+    downloadRangeButton.style.display = 'block';
+    downloadRangeButton.style.marginBottom = '10px';
     downloadRangeButton.onclick = () => {
         var rangeStart = parseInt(downloadRangeStart.value);
         var rangeEnd = parseInt(downloadRangeEnd.value);
@@ -115,28 +115,28 @@ var ignoreDuplicateTitles = true;
             }, 1);
 
             var doneInterval = setInterval(() => {
-                var loadMoreContainer = document.getElementsByClassName("expand-container")[0];
-                if (window.getComputedStyle(loadMoreContainer).display === "none") {
-                    downloadControls.style.display = "block";
+                var loadMoreContainer = document.getElementsByClassName('expand-container')[0];
+                if (window.getComputedStyle(loadMoreContainer).display === 'none') {
+                    downloadControls.style.display = 'block';
                     window.clearInterval(scrollInterval);
                     window.clearInterval(doneInterval);
-                    var collectionItems = document.getElementsByClassName("collection-item-container");
+                    var collectionItems = document.getElementsByClassName('collection-item-container');
                     var downloadedItems = [];
                     statusSpan.innerText = "Found the following albums:";
                     for (var i = 0; i < collectionItems.length; i++) {
                         var collectionItem = collectionItems[i];
-                        if (collectionItem.getElementsByClassName("redownload-item").length === 0) {
+                        if (collectionItem.getElementsByClassName('redownload-item').length === 0) {
                             continue; // skip non-downloads, i.e. subscriptions
                         }
-                        var itemDetails = collectionItem.getElementsByClassName("collection-item-details-container")[0];
-                        var albumTitle = itemDetails.getElementsByClassName("collection-item-title")[0].innerText;
-                        var albumArtist = itemDetails.getElementsByClassName("collection-item-artist")[0].innerText;
-                        var downloadLink = collectionItem.getElementsByClassName("redownload-item")[0].children[0].href;
+                        var itemDetails = collectionItem.getElementsByClassName('collection-item-details-container')[0];
+                        var albumTitle = itemDetails.getElementsByClassName('collection-item-title')[0].innerText;
+                        var albumArtist = itemDetails.getElementsByClassName('collection-item-artist')[0].innerText;
+                        var downloadLink = collectionItem.getElementsByClassName('redownload-item')[0].children[0].href;
                         var titleArtistKey = albumTitle + albumArtist;
                         var albumInfoContainer = document.createElement('div');
                         var includeCheckbox = document.createElement('input');
                         var titleArtistSpan = document.createElement('span');
-                        includeCheckbox.type = "checkbox";
+                        includeCheckbox.type = 'checkbox';
                         includeCheckbox.link = downloadLink;
                         albumInfoContainer.appendChild(includeCheckbox);
                         titleArtistSpan.innerText = allLinks.length + ": " + albumArtist.substring(3) + " - " + albumTitle;

--- a/DownloadCollection.user.js
+++ b/DownloadCollection.user.js
@@ -12,143 +12,143 @@
 var ignoreDuplicateTitles = true;
 
 (() => {
-    'use strict'
+    'use strict';
 
-    var allLinks = []
+    var allLinks = [];
 
-    var mainContainer = document.createElement('div')
+    var mainContainer = document.createElement('div');
     // close it via rightclick
     mainContainer.oncontextmenu = function () {
         mainContainer.style.display = 'none';
         return false;
     }
-    mainContainer.style.backgroundColor = "#1DA0C3"
-    mainContainer.style.position = "fixed"
-    mainContainer.style.color = "white"
-    mainContainer.style.top = "0"
-    mainContainer.style.left = "0"
-    mainContainer.style.right = "0"
-    mainContainer.style.padding = "20px"
-    mainContainer.style.zIndex = "9999999"
-    mainContainer.style.maxHeight = "75vh"
-    mainContainer.style.boxSizing = "border-box"
-    mainContainer.style.overflowY = "auto"
-    mainContainer.innerHTML = '<div><h2><a style="color: inherit" href="https://github.com/RyanBluth/Bandcamp-Greasy">BANDCAMP GREASY</a></h2></div>'
-    document.body.appendChild(mainContainer)
+    mainContainer.style.backgroundColor = "#1DA0C3";
+    mainContainer.style.position = "fixed";
+    mainContainer.style.color = "white";
+    mainContainer.style.top = "0";
+    mainContainer.style.left = "0";
+    mainContainer.style.right = "0";
+    mainContainer.style.padding = "20px";
+    mainContainer.style.zIndex = "9999999";
+    mainContainer.style.maxHeight = "75vh";
+    mainContainer.style.boxSizing = "border-box";
+    mainContainer.style.overflowY = "auto";
+    mainContainer.innerHTML = '<div><h2><a style="color: inherit" href="https://github.com/RyanBluth/Bandcamp-Greasy">BANDCAMP GREASY</a></h2></div>';
+    document.body.appendChild(mainContainer);
 
-    var statusSpan = document.createElement('span')
-    statusSpan.style.fontWeight = "bold"
-    statusSpan.innerText = "Loading albums..."
+    var statusSpan = document.createElement('span');
+    statusSpan.style.fontWeight = "bold";
+    statusSpan.innerText = "Loading albums...";
 
-    var downloadControls = document.createElement("div")
-    downloadControls.style.position = "fixed"
-    downloadControls.style.padding = "20px"
-    downloadControls.style.color = "black"
-    downloadControls.style.top = "0"
-    downloadControls.style.right = "0"
-    downloadControls.style.display = "none"
+    var downloadControls = document.createElement("div");
+    downloadControls.style.position = "fixed";
+    downloadControls.style.padding = "20px";
+    downloadControls.style.color = "black";
+    downloadControls.style.top = "0";
+    downloadControls.style.right = "0";
+    downloadControls.style.display = "none";
 
-    var downloadAllButton = document.createElement("button")
-    downloadAllButton.innerText = "Download All"
-    downloadAllButton.style.display = "block"
-    downloadAllButton.style.marginBottom = "10px"
+    var downloadAllButton = document.createElement("button");
+    downloadAllButton.innerText = "Download All";
+    downloadAllButton.style.display = "block";
+    downloadAllButton.style.marginBottom = "10px";
     downloadAllButton.onclick = function () {
         for (var i = 0; i < allLinks.length; i++) {
-            window.open(allLinks[i], '_blank')
+            window.open(allLinks[i], '_blank');
         }
     }
 
-    var downloadSelectedButton = document.createElement("button")
-    downloadSelectedButton.innerText = "Download Selected"
-    downloadSelectedButton.style.display = "block"
-    downloadSelectedButton.style.marginBottom = "10px"
+    var downloadSelectedButton = document.createElement("button");
+    downloadSelectedButton.innerText = "Download Selected";
+    downloadSelectedButton.style.display = "block";
+    downloadSelectedButton.style.marginBottom = "10px";
     downloadSelectedButton.onclick = function () {
-        var checkboxes = mainContainer.getElementsByTagName("input")
+        var checkboxes = mainContainer.getElementsByTagName("input");
         for (var i = 0; i < checkboxes.length; i++) {
             if (checkboxes[i].checked) {
-                window.open(checkboxes[i].link, '_blank')
+                window.open(checkboxes[i].link, '_blank');
             }
         }
     }
 
-    var downloadRangeStart = document.createElement("input")
-    downloadRangeStart.type = "text"
-    downloadRangeStart.style.display = "block"
-    downloadRangeStart.style.marginBottom = "10px"
-    downloadRangeStart.placeholder = "Range Start"
+    var downloadRangeStart = document.createElement("input");
+    downloadRangeStart.type = "text";
+    downloadRangeStart.style.display = "block";
+    downloadRangeStart.style.marginBottom = "10px";
+    downloadRangeStart.placeholder = "Range Start";
 
-    var downloadRangeEnd = document.createElement("input")
-    downloadRangeEnd.type = "text"
-    downloadRangeEnd.style.display = "block"
-    downloadRangeEnd.style.marginBottom = "10px"
-    downloadRangeEnd.placeholder = "Range End"
+    var downloadRangeEnd = document.createElement("input");
+    downloadRangeEnd.type = "text";
+    downloadRangeEnd.style.display = "block";
+    downloadRangeEnd.style.marginBottom = "10px";
+    downloadRangeEnd.placeholder = "Range End";
 
-    var downloadRangeButton = document.createElement("button")
-    downloadRangeButton.innerText = "Download Range"
-    downloadRangeButton.style.display = "block"
-    downloadRangeButton.style.marginBottom = "10px"
+    var downloadRangeButton = document.createElement("button");
+    downloadRangeButton.innerText = "Download Range";
+    downloadRangeButton.style.display = "block";
+    downloadRangeButton.style.marginBottom = "10px";
     downloadRangeButton.onclick = () => {
-        var rangeStart = parseInt(downloadRangeStart.value)
-        var rangeEnd = parseInt(downloadRangeEnd.value)
+        var rangeStart = parseInt(downloadRangeStart.value);
+        var rangeEnd = parseInt(downloadRangeEnd.value);
         for (var i = rangeStart; i <= rangeEnd && i < allLinks.length; i++) {
-            window.open(allLinks[i], '_blank')
+            window.open(allLinks[i], '_blank');
         }
     }
 
-    downloadControls.appendChild(downloadAllButton)
-    downloadControls.appendChild(downloadSelectedButton)
-    downloadControls.appendChild(downloadRangeButton)
-    downloadControls.appendChild(downloadRangeStart)
-    downloadControls.appendChild(downloadRangeEnd)
+    downloadControls.appendChild(downloadAllButton);
+    downloadControls.appendChild(downloadSelectedButton);
+    downloadControls.appendChild(downloadRangeButton);
+    downloadControls.appendChild(downloadRangeStart);
+    downloadControls.appendChild(downloadRangeEnd);
 
-    mainContainer.appendChild(downloadControls)
-    mainContainer.appendChild(statusSpan)
+    mainContainer.appendChild(downloadControls);
+    mainContainer.appendChild(statusSpan);
 
-    var showMoreButton = document.getElementsByClassName('show-more')[0]
+    var showMoreButton = document.getElementsByClassName('show-more')[0];
   
     setTimeout(() => {
-        showMoreButton.click()
+        showMoreButton.click();
         setTimeout(() => {
           
             var scrollInterval = setInterval(() => {
-                window.scrollTo(0, window.scrollY + 1000)
-            }, 1)
+                window.scrollTo(0, window.scrollY + 1000);
+            }, 1);
 
             var doneInterval = setInterval(() => {
-                var loadMoreContainer = document.getElementsByClassName("expand-container")[0]
+                var loadMoreContainer = document.getElementsByClassName("expand-container")[0];
                 if (window.getComputedStyle(loadMoreContainer).display === "none") {
-                    downloadControls.style.display = "block"
-                    window.clearInterval(scrollInterval)
-                    window.clearInterval(doneInterval)
-                    var collectionItems = document.getElementsByClassName("collection-item-container")
-                    var downloadedItems = []
-                    statusSpan.innerText = "Found the following albums:"
+                    downloadControls.style.display = "block";
+                    window.clearInterval(scrollInterval);
+                    window.clearInterval(doneInterval);
+                    var collectionItems = document.getElementsByClassName("collection-item-container");
+                    var downloadedItems = [];
+                    statusSpan.innerText = "Found the following albums:";
                     for (var i = 0; i < collectionItems.length; i++) {
-                        var collectionItem = collectionItems[i]
+                        var collectionItem = collectionItems[i];
                         if (collectionItem.getElementsByClassName("redownload-item").length === 0) {
-                            continue // skip non-downloads, i.e. subscriptions
+                            continue; // skip non-downloads, i.e. subscriptions
                         }
-                        var itemDetails = collectionItem.getElementsByClassName("collection-item-details-container")[0]
-                        var albumTitle = itemDetails.getElementsByClassName("collection-item-title")[0].innerText
-                        var albumArtist = itemDetails.getElementsByClassName("collection-item-artist")[0].innerText
-                        var downloadLink = collectionItem.getElementsByClassName("redownload-item")[0].children[0].href
-                        var titleArtistKey = albumTitle + albumArtist
-                        var albumInfoContainer = document.createElement('div')
-                        var includeCheckbox = document.createElement('input')
-                        var titleArtistSpan = document.createElement('span')
-                        includeCheckbox.type = "checkbox"
-                        includeCheckbox.link = downloadLink
-                        albumInfoContainer.appendChild(includeCheckbox)
-                        titleArtistSpan.innerText = allLinks.length + ": " + albumArtist.substring(3) + " - " + albumTitle
-                        albumInfoContainer.appendChild(titleArtistSpan)
-                        mainContainer.appendChild(albumInfoContainer)
+                        var itemDetails = collectionItem.getElementsByClassName("collection-item-details-container")[0];
+                        var albumTitle = itemDetails.getElementsByClassName("collection-item-title")[0].innerText;
+                        var albumArtist = itemDetails.getElementsByClassName("collection-item-artist")[0].innerText;
+                        var downloadLink = collectionItem.getElementsByClassName("redownload-item")[0].children[0].href;
+                        var titleArtistKey = albumTitle + albumArtist;
+                        var albumInfoContainer = document.createElement('div');
+                        var includeCheckbox = document.createElement('input');
+                        var titleArtistSpan = document.createElement('span');
+                        includeCheckbox.type = "checkbox";
+                        includeCheckbox.link = downloadLink;
+                        albumInfoContainer.appendChild(includeCheckbox);
+                        titleArtistSpan.innerText = allLinks.length + ": " + albumArtist.substring(3) + " - " + albumTitle;
+                        albumInfoContainer.appendChild(titleArtistSpan);
+                        mainContainer.appendChild(albumInfoContainer);
                         if (!ignoreDuplicateTitles || downloadedItems.indexOf(titleArtistKey) < 0) {
-                            allLinks.push(downloadLink)
+                            allLinks.push(downloadLink);
                         }
-                        downloadedItems.push(titleArtistKey)
+                        downloadedItems.push(titleArtistKey);
                     }
                 }
-            }, 2000)
-        }, 1000)
-    }, 2000)
-})()
+            }, 2000);
+        }, 1000);
+    }, 2000);
+})();

--- a/DownloadCollection.user.js
+++ b/DownloadCollection.user.js
@@ -1,9 +1,9 @@
 // ==UserScript==
 // @name         Bandcamp Download Collection
 // @namespace    https://bandcamp.com
-// @version      1.2
+// @version      1.3
 // @description  Opens the download page for each item in your collection.
-// @author       Ryan Bluth, Xerus2000
+// @author       Ryan Bluth, Xerus2000, bb010g
 // @match        https://bandcamp.com/YOUR_USERNAME
 // @grant        GM_openInTab
 // ==/UserScript==
@@ -11,144 +11,224 @@
 // Ignore albums with the same title and artist
 var ignoreDuplicateTitles = true;
 
-(() => {
+(function () {
     'use strict';
 
-    var allLinks = [];
+    // https://github.com/WebReflection/ustyler v1.0.1 | SPDX-License-Identifier(ISC) | Copyright (c) 2020, Andrea Giammarchi, @WebReflection
+    function css(template) {
+        const text = typeof template == 'string' ? [template] : [template[0]];
+        for (let i = 1, {length} = arguments; i < length; i++)
+            text.push(arguments[i], template[i]);
+        const style = document.createElement('style');
+        style.type = 'text/css';
+        style.appendChild(document.createTextNode(text.join('')));
+        return document.head.appendChild(style);
+    };
+    // end(ustyler)
 
-    var mainContainer = document.createElement('div');
-    // close it via rightclick
-    mainContainer.oncontextmenu = function () {
-        mainContainer.style.display = 'none';
-        return false;
+    // SPDX-License-Identifier(0BSD) | Copyright 2018, 2020 bb010g
+    var EventHandler = {handleEvent(event) { this['on' + event.type](event); }};
+    function createEventHandler(handler) {
+        if (!EventHandler.isPrototypeOf(handler)) { handler = Object.create(EventHandler, handler); }
+        return handler;
     }
-    mainContainer.style.backgroundColor = '#1DA0C3';
-    mainContainer.style.position = 'fixed';
-    mainContainer.style.color = 'white';
-    mainContainer.style.top = '0';
-    mainContainer.style.left = '0';
-    mainContainer.style.right = '0';
-    mainContainer.style.padding = '20px';
-    mainContainer.style.zIndex = '9999999';
-    mainContainer.style.maxHeight = '75vh';
-    mainContainer.style.boxSizing = 'border-box';
-    mainContainer.style.overflowY = 'auto';
-    mainContainer.innerHTML = '<div><h2><a style="color: inherit" href="https://github.com/RyanBluth/Bandcamp-Greasy">BANDCAMP GREASY</a></h2></div>';
-    document.body.appendChild(mainContainer);
-
-    var statusSpan = document.createElement('span');
-    statusSpan.style.fontWeight = 'bold';
-    statusSpan.innerText = "Loading albums...";
-
-    var downloadControls = document.createElement('div');
-    downloadControls.style.position = 'fixed';
-    downloadControls.style.padding = '20px';
-    downloadControls.style.color = 'black';
-    downloadControls.style.top = '0';
-    downloadControls.style.right = '0';
-    downloadControls.style.display = 'none';
-
-    var downloadAllButton = document.createElement('button');
-    downloadAllButton.innerText = "Download All";
-    downloadAllButton.style.display = 'block';
-    downloadAllButton.style.marginBottom = '10px';
-    downloadAllButton.onclick = function () {
-        for (var i = 0; i < allLinks.length; i++) {
-            window.open(allLinks[i], '_blank');
+    function addEventHandler(target, handler) {
+        for (const type of Object.getOwnPropertyNames(handler)) {
+            if (/^on/.test(type)) { target.addEventListener(type.slice(2), handler); }
         }
+        target.eventHandler = handler;
     }
+    function element(tagName, props = {}, children = [], eventHandler = {}) {
+        const el = document.createElement(tagName);
+        Object.assign(el, props);
+        el.append(...children);
+        addEventHandler(el, createEventHandler(eventHandler));
+        return el;
+    };
+    // end
 
-    var downloadSelectedButton = document.createElement('button');
-    downloadSelectedButton.innerText = "Download Selected";
-    downloadSelectedButton.style.display = 'block';
-    downloadSelectedButton.style.marginBottom = '10px';
-    downloadSelectedButton.onclick = function () {
-        var checkboxes = mainContainer.getElementsByTagName('input');
-        for (var i = 0; i < checkboxes.length; i++) {
-            if (checkboxes[i].checked) {
-                window.open(checkboxes[i].link, '_blank');
-            }
+    function newMouseEvent(type, view) { return new MouseEvent(type, {bubbles: true, cancelable: true, view: view}); }
+
+    var style = css`
+        #bandcamp-greasy {
+            background-color: #1DA0C3;
+            position: fixed;
+            color: white;
+            top: 0;
+            left: 0;
+            right: 0;
+            padding: 20px;
+            z-index: 9999999;
+            max-height: 75vh;
+            box-sizing: border-box;
+            overflow-y: auto;
+            display: flex;
+            flex-direction: column;
         }
-    }
-
-    var downloadRangeStart = document.createElement('input');
-    downloadRangeStart.type = 'text';
-    downloadRangeStart.style.display = 'block';
-    downloadRangeStart.style.marginBottom = '10px';
-    downloadRangeStart.placeholder = "Range Start";
-
-    var downloadRangeEnd = document.createElement('input');
-    downloadRangeEnd.type = 'text';
-    downloadRangeEnd.style.display = 'block';
-    downloadRangeEnd.style.marginBottom = '10px';
-    downloadRangeEnd.placeholder = "Range End";
-
-    var downloadRangeButton = document.createElement('button');
-    downloadRangeButton.innerText = "Download Range";
-    downloadRangeButton.style.display = 'block';
-    downloadRangeButton.style.marginBottom = '10px';
-    downloadRangeButton.onclick = () => {
-        var rangeStart = parseInt(downloadRangeStart.value);
-        var rangeEnd = parseInt(downloadRangeEnd.value);
-        for (var i = rangeStart; i <= rangeEnd && i < allLinks.length; i++) {
-            window.open(allLinks[i], '_blank');
+        #bandcamp-greasy a { color: inherit; }
+        #bandcamp-greasy li { margin-top: unset; margin-bottom: unset; }
+        #bandcamp-greasy > * {
+            display: grid;
+            grid-template-columns: auto fit-content(30em);
+            grid-auto-rows: fit-content(50vh);
         }
-    }
+        #bandcamp-greasy > * > * { grid-column: 1; overflow-y: auto; }
+        #bandcamp-greasy > * > .controls { grid-column: 2; overflow-y: unset; }
+        #bandcamp-greasy h2 { text-transform: uppercase; }
+        #bandcamp-greasy > .status {
+            font-weight: bold;
+        }
+        #bandcamp-greasy .controls {
+            color: black;
+            display: flex;
+            flex-direction: row;
+            flex-wrap: wrap;
+            align-items: center;
+            align-content: center;
+            justify-content: flex-end;
+        }
+        #bandcamp-greasy .controls > button, #bandcamp-greasy .controls > input::placeholder {
+            text-transform: capitalize;
+        }
+        #bandcamp-greasy .controls > * {
+            display: block;
+            margin-bottom: 10px;
+        }
+        #bandcamp-greasy .album-infos .album-info input[type="checkbox"]:disabled ~ .item {
+            text-decoration: line-through;
+        }
+    `;
 
-    downloadControls.appendChild(downloadAllButton);
-    downloadControls.appendChild(downloadSelectedButton);
-    downloadControls.appendChild(downloadRangeButton);
-    downloadControls.appendChild(downloadRangeStart);
-    downloadControls.appendChild(downloadRangeEnd);
-
-    mainContainer.appendChild(downloadControls);
-    mainContainer.appendChild(statusSpan);
-
-    var showMoreButton = document.getElementsByClassName('show-more')[0];
-  
-    setTimeout(() => {
-        showMoreButton.click();
-        setTimeout(() => {
-          
-            var scrollInterval = setInterval(() => {
-                window.scrollTo(0, window.scrollY + 1000);
-            }, 1);
-
-            var doneInterval = setInterval(() => {
-                var loadMoreContainer = document.getElementsByClassName('expand-container')[0];
-                if (window.getComputedStyle(loadMoreContainer).display === 'none') {
-                    downloadControls.style.display = 'block';
-                    window.clearInterval(scrollInterval);
-                    window.clearInterval(doneInterval);
+    var mainContainer = element('div', {id: 'bandcamp-greasy'}, [
+        element('div', {className: 'header'}, [
+            element('h2', {innerHTML: `<a style="color: inherit" href="https://github.com/RyanBluth/Bandcamp-Greasy">Bandcamp Greasy</a>`}),
+            element('div', {className: 'controls'}, [
+                element('button', {className: 'close', textContent: "Close"}, [], {onclick: {value(e) {
+                    hideMainContainer();
+                }}}),
+                element('button', {className: 'retry-pagination', textContent: "Retry pagination"}, [], {onclick: {value(e) {
+                    var collectionGrid = window.CollectionGrids.collection;
+                    if (collectionGrid.paginating) {
+                        return;
+                    }
+                    if (collectionGrid.error) {
+                        collectionGrid.error = false;
+                    }
+                    collectionGrid.paginate();
+                }}}),
+            ]),
+        ]),
+        element('div', {className: 'albums'}, [
+            element('span', {className: 'status', textContent: "No albums loaded."}),
+            element('div', {className: 'controls'}, [
+                element('button', {className: 'clear-scanned-albums', textContent: "Clear scanned albums"}, [], {onclick: {value(e) {
+                    var parent = e.target.parentNode;
+                    parent.parentNode.querySelector('.album-infos').textContent = '';
+                    parent.parentNode.querySelector('.status').textContent = "No albums loaded.";
+                }}}),
+                element('button', {className: 'scan-albums', textContent: "Scan albums"}, [], {onclick: {value(e) {
+                    if (e.target.disabled) { return; }
+                    e.target.disabled = true;
+                    var albumInfos = e.target.parentNode.parentNode.querySelector('.album-infos');
                     var collectionItems = document.getElementsByClassName('collection-item-container');
-                    var downloadedItems = [];
-                    statusSpan.innerText = "Found the following albums:";
+                    document.querySelector('#bandcamp-greasy span.status').textContent = "Found the following albums:";
                     for (var i = 0; i < collectionItems.length; i++) {
                         var collectionItem = collectionItems[i];
                         if (collectionItem.getElementsByClassName('redownload-item').length === 0) {
                             continue; // skip non-downloads, i.e. subscriptions
                         }
                         var itemDetails = collectionItem.getElementsByClassName('collection-item-details-container')[0];
-                        var albumTitle = itemDetails.getElementsByClassName('collection-item-title')[0].innerText;
-                        var albumArtist = itemDetails.getElementsByClassName('collection-item-artist')[0].innerText;
-                        var downloadLink = collectionItem.getElementsByClassName('redownload-item')[0].children[0].href;
-                        var titleArtistKey = albumTitle + albumArtist;
-                        var albumInfoContainer = document.createElement('div');
-                        var includeCheckbox = document.createElement('input');
-                        var titleArtistSpan = document.createElement('span');
-                        includeCheckbox.type = 'checkbox';
-                        includeCheckbox.link = downloadLink;
-                        albumInfoContainer.appendChild(includeCheckbox);
-                        titleArtistSpan.innerText = allLinks.length + ": " + albumArtist.substring(3) + " - " + albumTitle;
-                        albumInfoContainer.appendChild(titleArtistSpan);
-                        mainContainer.appendChild(albumInfoContainer);
-                        if (!ignoreDuplicateTitles || downloadedItems.indexOf(titleArtistKey) < 0) {
-                            allLinks.push(downloadLink);
+                        var itemLink = collectionItem.getElementsByClassName('item-link')[0];
+                        var albumTitle = itemDetails.getElementsByClassName('collection-item-title')[0];
+                        var albumArtist = itemDetails.getElementsByClassName('collection-item-artist')[0];
+                        var downloadLink = collectionItem.getElementsByClassName('redownload-item')[0].children[0];
+                        var includeCheckbox = element('input', {type: 'checkbox'});
+                        for (var existingItemLink of albumInfos.querySelectorAll('li > label > a.item')) {
+                            if (existingItemLink.href === itemLink.href) {
+                                includeCheckbox.disabled = true;
+                                break;
+                            }
                         }
-                        downloadedItems.push(titleArtistKey);
+                        albumInfos.appendChild(element('li', {className: 'album-info'}, [
+                            element('label', {}, [
+                                includeCheckbox,
+                                element('a', {className: 'item', href: itemLink.href, target: '_blank'}, [
+                                    element('span', {className: 'artist', textContent: albumArtist.innerText.substring(3)}),
+                                    ' - ',
+                                    element('span', {className: 'album', textContent: albumTitle.innerText}),
+                                ]),
+                                ' ',
+                                element('a', {className: 'download', href: downloadLink.href, target: '_blank'}, ['(download)']),
+                            ]),
+                        ]));
                     }
-                }
-            }, 2000);
-        }, 1000);
+                    e.target.disabled = false;
+                }}}),
+                element('button', {className: 'auto-scan-albums', textContent: "Auto-scan albums"}, [], {onclick: {value(e) {
+                    if (e.target.disabled) { return; }
+                    e.target.disabled = true;
+                    var parent = e.target.parentNode;
+                    parent.parentNode.querySelector('.status').textContent = "Loading albums...";
+                    document.querySelector('#collection-items .show-more').click();
+
+                    setTimeout(function () {
+                        var scrollInterval = setInterval(function () {
+                            window.scrollTo(0, window.scrollY + 1000);
+                        }, 1);
+            
+                        var doneInterval = setInterval(function () {
+                            var loadMoreContainer = document.getElementsByClassName('expand-container')[0];
+                            if (window.getComputedStyle(loadMoreContainer).display === 'none') {
+                                showMainContainer();
+                                window.clearInterval(scrollInterval);
+                                window.clearInterval(doneInterval);
+                                e.target.disabled = false;
+                                parent.querySelector('.scan-albums').dispatchEvent(newMouseEvent('click', e.view));
+                            }
+                        }, 2000);
+                    }, 1000);
+                }}}),
+            ]),
+            element('ol', {className: 'album-infos', start: 0}),
+            element('div', {className: 'controls'}, [
+                element('button', {className: 'download-all', textContent: "Download all"}, [], {onclick: {value(e) {
+                    for (var link of e.target.parentNode.parentNode.querySelectorAll('.album-infos .album-info input[type="checkbox"]:enabled ~ a.download')) {
+                        window.open(link.href, '_blank');
+                    }
+                }}}),
+                element('button', {className: 'download-selected', textContent: "Download selected"}, [], {onclick: {value(e) {
+                    for (var link of e.target.parentNode.parentNode.querySelectorAll('.album-infos .album-info input[type="checkbox"]:enabled:checked ~ a.download')) {
+                        window.open(link.href, '_blank');
+                    }
+                }}}),
+                element('input', {type: 'text', className: 'download-range range-start', placeholder: "Range start"}),
+                element('input', {type: 'text', className: 'download-range range-end', placeholder: "Range end"}),
+                element('button', {className: 'download-range', textContent: "Download range"}, [], {onclick: {value(e) {
+                    var parent = e.target.parentNode;
+                    var albumInfos = parent.parentNode.querySelectorAll('.album-infos > li');
+                    var rangeStart = parseInt(parent.querySelector('.download-range.range-start').value);
+                    var rangeEnd = parseInt(parent.querySelector('.download-range.range-end').value);
+                    for (var i = rangeStart; i <= rangeEnd && i < albumInfos.length; i++) {
+                        var link = albumInfos[i].querySelector('input[type="checkbox"]:enabled ~ a.download');
+                        if (link != null) { window.open(link.href, '_blank'); }
+                    }
+                }}}),
+            ]),
+        ]),
+    ]);
+    mainContainer.style.display = 'none';
+    document.body.appendChild(mainContainer);
+
+    function hideMainContainer() {
+        var mainContainer = document.getElementById('bandcamp-greasy');
+        if (mainContainer.style.display !== 'none') { mainContainer.style.display = 'none'; }
+    }
+    function showMainContainer() {
+        var mainContainer = document.getElementById('bandcamp-greasy');
+        if (mainContainer.style.display === 'none') { mainContainer.style.display = null; }
+    }
+
+    setTimeout(function () {
+        showMainContainer();
     }, 2000);
 })();

--- a/DownloadCollection.user.js
+++ b/DownloadCollection.user.js
@@ -18,7 +18,7 @@ var ignoreDuplicateTitles = true;
 
     var mainContainer = document.createElement('div')
     // close it via rightclick
-    mainContainer.oncontextmenu = function (){
+    mainContainer.oncontextmenu = function () {
         mainContainer.style.display = 'none';
         return false;
     }
@@ -112,7 +112,6 @@ var ignoreDuplicateTitles = true;
           
             var scrollInterval = setInterval(() => {
                 window.scrollTo(0, window.scrollY + 1000)
-
             }, 1)
 
             var doneInterval = setInterval(() => {


### PR DESCRIPTION
DownloadCollection can now deal with flaky & slow connections and minor Bandcamp errors (without requiring a full refresh & reset), has easier-to-read duplicate listings, doesn't start auto-scanning every single time you open your page if it's left on, and allows for a reset from wherever you are if it somehow messes up.

(The internet was bad when I started messing around with this, so here's the result.)

State is also now stored in the DOM, so bodges on Bandcamp Greasey in your web inspector are simpler & more effective. (For example, you can manually remove a bunch of listed albums from the DOM, and range downloading will still work as if you never removed anything.) Multiple concurrent auto-scans are prevented by disabling the button while an auto-scan is running, which feels nice for this sort of userscript.

A bit longer due to some helper functions for the UI HTML & switching over to proper CSS for styling. Credit to https://webreflection.medium.com/dom-handleevent-a-cross-platform-standard-since-year-2000-5bf17287fd38 for the EventHandler pattern.

I ended up adding semicolons to the ends of lines. I hope that's okay.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ryanbluth/bandcamp-greasy/22)
<!-- Reviewable:end -->
