### PR TITLE
DownloadAlbum: open dowload in same window and wait before closing

### DIFF
--- a/DownloadAlbum.user.js
+++ b/DownloadAlbum.user.js
@@ -47,10 +47,10 @@
 
                 var titleLabel = document.getElementsByClassName('download-title')[0];
                 if (titleLabel.children[0].href !== undefined && titleLabel.children[0].href.length > 0) {
-                    window.open(titleLabel.children[0].href);
+                    window.open(titleLabel.children[0].href, "_self");
                     clearTimeout(interval);
                     if (closeAfterDownload) {
-                        close();
+                        setTimeout(function() {close()}, 20000);
                     }
                 }
             }


### PR DESCRIPTION
This opens the download link in the same window, so no empty tabs are left around when browser is set to open in new tabs.

Also, window is only closed after some delay (20s) which should leave the download enough time to get started.
