### PR TITLE
Fix format selection

### DIFF
--- a/DownloadAlbum.user.js
+++ b/DownloadAlbum.user.js
@@ -3,8 +3,8 @@
 // @namespace   https://bandcamp.com
 // @match       https://bandcamp.com/download*
 // @description Downloads the item from the download page. Refreshes if there is an error.
-// @author      Ryan Bluth, Xerus2000, Kélian Steffe
-// @version     1.2
+// @author      Ryan Bluth, Xerus2000, Kélian Steffe, Cook I.T!
+// @version     1.2.1
 // @grant       none
 // ==/UserScript==
 
@@ -25,6 +25,7 @@
               	for(var option of options) {
                   if(option.textContent.split(" - ")[0] == format) {
                     option.selected = true;
+                    option.parentNode.dispatchEvent(new Event('change'));
                     selectedFormat = true;
                     break;
                   }

--- a/DownloadAlbum.user.js
+++ b/DownloadAlbum.user.js
@@ -24,8 +24,10 @@
 
               	for(var option of options) {
                   if(option.textContent.split(" - ")[0] == format) {
-                    option.selected = true;
-                    option.parentNode.dispatchEvent(new Event('change'));
+                    if(option.selected != true) {
+                        option.selected = true;
+                        option.parentNode.dispatchEvent(new Event('change'));
+                    }
                     selectedFormat = true;
                     break;
                   }


### PR DESCRIPTION
When setting `option.selected = true;`, the "change" event (which creates the download link for the selected format) doesn't fire. Calling `.dispatchEvent(new Event('change'))` on the `<select>` element (the parent) fixes that issue.

I haven't thoroughly tested this, it works for me on Waterfox G6.0.8 (64-bit) using Violentmonkey v2.18.0.